### PR TITLE
Add handler for /v1/check and simplify main().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 .vscode/
+cmd/switch-monitoring/switch-monitoring

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	defaultListenAddr = ":8080"
-	defaultPromPort   = ":9600"
 	defaultProjectID  = "mlab-sandbox"
 
 	switchHostFormat  = "s1.%s.measurement-lab.org"

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -104,10 +104,6 @@ func main() {
 	rtx.Must(httpx.ListenAndServeAsync(s), "Could not start HTTP server")
 	defer s.Close()
 
-	// Initialize Prometheus server for monitoring.
-	// promServer := prometheusx.MustServeMetrics()
-	// defer promServer.Close()
-
 	// Keep serving until the context is canceled.
 	<-ctx.Done()
 }

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/text"
-	"github.com/goji/httpauth"
 	"github.com/scottdware/go-junos"
 
 	"github.com/m-lab/go/flagx"
@@ -38,9 +37,6 @@ var (
 		"Path to the SSH private key to use.")
 	sshPassphrase = flag.String("ssh.passphrase", "",
 		"Passphrase to decrypt the private key. Can be omitted.")
-
-	authUsername = flag.String("auth.username", "", "Username for HTTP basic auth")
-	authPassword = flag.String("auth.password", "", "Password for HTTP basic auth")
 
 	debug = flag.Bool("debug", true, "Show debug messages.")
 
@@ -81,19 +77,6 @@ func main() {
 	netconf := newNetconf(auth)
 
 	collectorHandler = collector.NewHandler(*project, netconf)
-
-	if *authUsername != "" && *authPassword != "" {
-		authOpts := httpauth.AuthOptions{
-			Realm:    "switch-monitoring",
-			User:     *authUsername,
-			Password: *authPassword,
-		}
-		collectorHandler = httpauth.BasicAuth(authOpts)(collectorHandler)
-	} else {
-		log.Warn("Username and password have not been specified!")
-		log.Warn("Make sure you add -auth.username and -auth.password before " +
-			"running in production.")
-	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/v1/check", collectorHandler)

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -91,7 +91,7 @@ func main() {
 	}
 	netconf := newNetconf(auth)
 
-	collectorHandler = collector.NewHandler(*flagProject, netconf)
+	collectorHandler = collector.NewHandler(*project, netconf)
 
 	// Create an in-memory cache to avoid connecting to a switch too often.
 	//

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -52,9 +52,9 @@ var (
 	flagPassword = flag.String("auth.password", "", "Password for HTTP basic auth")
 
 	flagCacheCapacity = flag.Int("collector.cache-capacity", defaultCacheCapacity,
-		"Maximum # of cached responses for the e2e endpoint")
+		"Maximum # of cached responses for the /check endpoint")
 	flagCacheTTL = flag.Duration("collector.cache-ttl", defaultCacheTTL,
-		"TTL of cached responses for the e2e endpoint")
+		"TTL of cached responses for the /check endpoint")
 
 	flagDebug = flag.Bool("debug", true, "Show debug messages.")
 

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -23,6 +23,8 @@ const (
 	defaultListenAddr = ":8080"
 	defaultProjectID  = "mlab-sandbox"
 
+	// TODO: use v2 hostnames once they are available.
+	// (https://github.com/m-lab/siteinfo/issues/134)
 	switchHostFormat  = "s1.%s.measurement-lab.org"
 	siteinfoVersion   = "v1"
 	httpClientTimeout = time.Second * 15

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -97,6 +97,21 @@ func main() {
 	collectorHandler = collector.NewHandler(*flagProject, netconf)
 
 	// Create an in-memory cache to avoid connecting to a switch too often.
+	//
+	// Assuming we have enough capacity to keep all the responses in the cache,
+	// the choice of eviction algorithm does not really make a difference.
+	//
+	// If we don't have enough capacity to keep all the responses in memory:
+	//
+	//   - By using MRU, the first capacity - 1 responses will be re-used for
+	//     24 hours and switches - capacity + 1 new SSH connections will be
+	//     made.
+	//   - By using LRU, all the SSH connections will be made each time.
+	//
+	// Both conditions are very undesirable and we should make sure
+	// capacity > switches at all times. However, using MRU significantly
+	// limits the impact when this does not hold true anymore.
+
 	memcache, err := memory.NewAdapter(
 		memory.AdapterWithAlgorithm(memory.MRU),
 		memory.AdapterWithCapacity(*flagCacheCapacity),

--- a/cmd/switch-monitoring/main_test.go
+++ b/cmd/switch-monitoring/main_test.go
@@ -72,11 +72,20 @@ func Test_main(t *testing.T) {
 
 	go main()
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 	cancel()
 
-	restoreKey()
+	restoreUser := osx.MustSetenv("AUTH_USERNAME", "test")
+	restorePass := osx.MustSetenv("AUTH_PASSWORD", "test")
+	go main()
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	restoreUser()
+	restorePass()
 	restorePort()
+	restoreKey()
 	newNetconf = oldNewNetconf
 }
 

--- a/cmd/switch-monitoring/main_test.go
+++ b/cmd/switch-monitoring/main_test.go
@@ -1,17 +1,12 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/m-lab/go/content"
 	"github.com/m-lab/go/osx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/switch-monitoring/internal"
@@ -40,38 +35,6 @@ func (n *mockNetconf) GetConfig(hostname string, section ...string) (string, err
 	return string(config), nil
 }
 
-type mockHTTPProvider struct {
-	// How many times Get has been called.
-	getCalled    int
-	mustFail     bool
-	responseBody string
-}
-
-func (prov *mockHTTPProvider) Get(string) (*http.Response, error) {
-	prov.getCalled++
-	if prov.mustFail {
-		return nil, fmt.Errorf("error")
-	}
-	return &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewBufferString(prov.responseBody)),
-		StatusCode: http.StatusOK,
-	}, nil
-}
-
-type mockConfigProvider struct {
-	configFile string
-	mustFail   bool
-}
-
-func (c mockConfigProvider) Get(context.Context) ([]byte, error) {
-	if c.mustFail {
-		return nil, fmt.Errorf("Get() failed")
-	}
-	config, err := ioutil.ReadFile(c.configFile)
-	rtx.Must(err, "Cannot read test data")
-	return config, nil
-}
-
 //
 // Tests.
 //
@@ -81,26 +44,10 @@ func Test_main(t *testing.T) {
 	netconf := &mockNetconf{
 		configFile: "testdata/abc01.conf",
 	}
-	siteinfo := &mockHTTPProvider{
-		responseBody: `{"abc01": {}}`,
-	}
-	configProvider := &mockConfigProvider{
-		configFile: "testdata/abc01.conf",
-	}
 
 	oldNewNetconf := newNetconf
 	newNetconf = func(auth *junos.AuthMethod) internal.NetconfClient {
 		return netconf
-	}
-
-	oldHTTPClient := httpClient
-	httpClient = func(timeout time.Duration) internal.HTTPProvider {
-		return siteinfo
-	}
-
-	oldConfigFromURL := configFromURL
-	configFromURL = func(ctx context.Context, u *url.URL) (content.Provider, error) {
-		return configProvider, nil
 	}
 
 	// Replace osExit so that tests don't stop running.
@@ -120,27 +67,17 @@ func Test_main(t *testing.T) {
 	assert.PanicsWithValue("os.Exit called", main,
 		"os.Exit was not called")
 
-	restore := osx.MustSetenv("KEY", "/path/to/key")
+	restoreKey := osx.MustSetenv("SSH_KEY", "/path/to/key")
+	restorePort := osx.MustSetenv("LISTENADDR", ":0")
 
-	main()
-	if netconf.getConfigCalled == 0 {
-		t.Errorf("GetConfig() has not been called.")
-	}
+	go main()
 
-	if siteinfo.getCalled == 0 {
-		t.Errorf("Get() has not been called.")
-	}
+	time.Sleep(1 * time.Second)
+	cancel()
 
-	// Make GetConfig() fail.
-	netconf.mustFail = true
-	main()
-	netconf.mustFail = false
-
-	restore()
+	restoreKey()
+	restorePort()
 	newNetconf = oldNewNetconf
-	httpClient = oldHTTPClient
-	configFromURL = oldConfigFromURL
-
 }
 
 func Test_newNetconf(t *testing.T) {
@@ -148,125 +85,4 @@ func Test_newNetconf(t *testing.T) {
 	if netconf == nil {
 		t.Errorf("newNetconf() returned nil.")
 	}
-}
-
-func Test_httpClient(t *testing.T) {
-	client := httpClient(0)
-	if client == nil {
-		t.Errorf("httpClient() returned nil.")
-	}
-}
-
-func Test_configFromURL(t *testing.T) {
-	url, err := url.Parse("gs://test/file")
-	rtx.Must(err, "Cannot create test URL")
-	config, err := configFromURL(context.Background(), url)
-	if err != nil {
-		t.Errorf("configFromURL() returned err: %v", err)
-	}
-	if config == nil {
-		t.Errorf("httpClient() returned nil.")
-	}
-}
-
-func Test_sites(t *testing.T) {
-	siteinfo := &mockHTTPProvider{}
-
-	oldHTTPClient := httpClient
-	httpClient = func(timeout time.Duration) internal.HTTPProvider {
-		return siteinfo
-	}
-
-	siteinfo.responseBody = `{"abc01": {}}`
-	res, err := sites("test")
-	if err != nil {
-		t.Errorf("sites() returned err: %v", err)
-	}
-	if len(res) != 1 {
-		t.Errorf("sites(): expected one string, found %v", len(res))
-	}
-
-	// Get() fails.
-	siteinfo.mustFail = true
-	_, err = sites("test")
-	if err == nil {
-		t.Errorf("sites(): expected err, got nil.")
-	}
-	siteinfo.mustFail = false
-
-	// No content.
-	siteinfo.responseBody = ``
-	_, err = sites("test")
-	if err == nil {
-		t.Errorf("sites(): expected err, got nil.")
-	}
-
-	// JSON is an empty object.
-	siteinfo.responseBody = `{}`
-	_, err = sites("test")
-	if err == nil {
-		t.Errorf("sites(): expected err, got nil.")
-	}
-
-	httpClient = oldHTTPClient
-}
-
-func Test_checkAll(t *testing.T) {
-	// Set up test conditions.
-	oldConfigFromURL := configFromURL
-
-	configProvider := &mockConfigProvider{
-		configFile: "testdata/abc01.conf",
-	}
-	configFromURL = func(ctx context.Context, u *url.URL) (content.Provider, error) {
-		return configProvider, nil
-	}
-
-	//
-	// Tests begin here.
-	//
-
-	tests := []struct {
-		name           string
-		netconf        internal.NetconfClient
-		sites          []string
-		configMustFail bool
-	}{
-		{
-			name: "ok",
-			netconf: &mockNetconf{
-				configFile: "testdata/abc01.conf",
-			},
-			sites: []string{"abc01"},
-		},
-		{
-			name: "config-mismatch",
-			netconf: &mockNetconf{
-				configFile: "testdata/abc02.conf",
-			},
-			sites: []string{"abc02"},
-		},
-		{
-			name: "netconf-get-config-fails",
-			netconf: &mockNetconf{
-				mustFail: true,
-			},
-			sites: []string{"abc01"},
-		},
-		{
-			name: "config-provider-fails",
-			netconf: &mockNetconf{
-				configFile: "testdata/abc01.conf",
-			},
-			sites:          []string{"abc01"},
-			configMustFail: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configProvider.mustFail = tt.configMustFail
-			checkAll(tt.netconf, tt.sites)
-		})
-	}
-	configFromURL = oldConfigFromURL
 }

--- a/cmd/switch-monitoring/main_test.go
+++ b/cmd/switch-monitoring/main_test.go
@@ -75,15 +75,6 @@ func Test_main(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	cancel()
 
-	restoreUser := osx.MustSetenv("AUTH_USERNAME", "test")
-	restorePass := osx.MustSetenv("AUTH_PASSWORD", "test")
-	go main()
-
-	time.Sleep(500 * time.Millisecond)
-	cancel()
-
-	restoreUser()
-	restorePass()
 	restorePort()
 	restoreKey()
 	newNetconf = oldNewNetconf

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/prometheus/client_golang v1.3.0
 	github.com/scottdware/go-junos v0.0.0-20191101184514-da1ec4631b03
 	github.com/stretchr/testify v1.5.1
+	github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/apex/log v1.1.2
 	github.com/fsouza/fake-gcs-server v1.18.1 // indirect
+	github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d
 	github.com/kylelemons/godebug v1.1.0
 	github.com/m-lab/go v1.3.1-0.20200403144322-d726433a0387
 	github.com/m-lab/uuid-annotator v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLD
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
+github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707 h1:Pg/LJmFZnr+hlP9sohJKDaxi1nTSOPvGNo8dBBgRIkM=
+github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707/go.mod h1:V7CEaXWuLs0tH3DNWqJO+GVr8YgiAwRgBh76T4LNSPU=
 github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b h1:VfPXB/wCGGt590QhD1bOpv2J/AmC/RJNTg/Q59HKSB0=
 github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b/go.mod h1:IZpXDfkJ6tWD3PhBK5YzgQT+xJWh7OsdwiG8hA2MkO4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d h1:lBXNCxVENCipq4D1Is42JVOP4eQjlB8TQ6H69Yx5J9Q=
+github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/collector/handler.go
+++ b/internal/collector/handler.go
@@ -1,0 +1,109 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/apex/log"
+	"github.com/m-lab/go/content"
+	"github.com/m-lab/switch-monitoring/internal"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Handler is the HTTP handler for /check
+type Handler struct {
+	projectID string
+	netconf   internal.NetconfClient
+}
+
+// NewHandler returns a Handler with the specified configuration.
+func NewHandler(projectID string, netconf internal.NetconfClient) *Handler {
+	return &Handler{
+		projectID: projectID,
+		netconf:   netconf,
+	}
+}
+
+// ServeHTTP handles GET requests to the /check endpoint, parsing the target
+// parameter and delegating writing the actual response to promhttp.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	target := r.URL.Query().Get("target")
+	if len(target) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("URL parameter 'target' is missing"))
+		log.Info("URL parameter 'target' is missing")
+		return
+	}
+
+	site, err := getSite(target)
+	if err != nil {
+		writeError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	provider, err := h.getProviderForConfig(site)
+	if err != nil {
+		writeError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	config := Config{
+		ProjectID: h.projectID,
+		Netconf:   h.netconf,
+		Provider:  provider,
+	}
+
+	registry := prometheus.NewRegistry()
+	collector := New(target, config)
+	registry.MustRegister(collector)
+
+	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	promHandler.ServeHTTP(w, r)
+}
+
+// getProviderForConfig initializes a content.Provider for the specified site.
+func (h *Handler) getProviderForConfig(site string) (content.Provider, error) {
+	url, err := url.Parse(
+		fmt.Sprintf("gs://switch-config-%s/configs/latest/%s.conf",
+			h.projectID, site),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := content.FromURL(context.Background(), url)
+	if err != nil {
+		return nil, err
+	}
+
+	return provider, nil
+}
+
+// getSite returns the site name from a FQDN like
+// s1.<site>.measurement-lab.org.
+func getSite(hostname string) (string, error) {
+	re := regexp.MustCompile(`s1\.([a-zA-Z]{3}[0-9]{2}).*`)
+	res := re.FindStringSubmatch(hostname)
+	if len(res) != 2 {
+		return "", fmt.Errorf("cannot extract site from hostname: %s",
+			hostname)
+	}
+
+	return res[0], nil
+}
+
+// writeError writes an error on the provided ResponseWriter and logs it.
+func writeError(w http.ResponseWriter, err error, status int) {
+	w.WriteHeader(status)
+	w.Write([]byte(err.Error()))
+	log.WithError(err).Error("Error while processing request")
+}

--- a/internal/collector/handler_test.go
+++ b/internal/collector/handler_test.go
@@ -1,0 +1,122 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/m-lab/go/content"
+)
+
+func TestNewHandler(t *testing.T) {
+	netconf := &netconfProvider{}
+	h := NewHandler("test", netconf)
+	if h == nil || h.netconf != netconf || h.projectID != "test" {
+		t.Errorf("NewHandler() didn't return the expected value")
+	}
+}
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	metadata := `# HELP switch_monitoring_config_match Configuration check result for this target
+# TYPE switch_monitoring_config_match gauge
+`
+
+	tests := []struct {
+		name              string
+		r                 *http.Request
+		status            int
+		body              string
+		getConfigMustFail bool
+	}{
+		{
+			name: "ok-configs-match",
+			r: httptest.NewRequest("GET",
+				"/v1/check?target=s1.abc01.measurement-lab.org", nil),
+			status: http.StatusOK,
+			body: metadata + `switch_monitoring_config_match{status="ok",` +
+				`target="s1.abc01.measurement-lab.org"} 1
+`,
+		},
+		{
+			name:   "method-not-allowed",
+			r:      httptest.NewRequest("POST", "/v1/check", nil),
+			status: http.StatusMethodNotAllowed,
+		},
+		{
+			name:   "target-not-provided",
+			r:      httptest.NewRequest("GET", "/v1/check", nil),
+			status: http.StatusBadRequest,
+			body:   "URL parameter 'target' is missing",
+		},
+		{
+			name:   "invalid-target",
+			r:      httptest.NewRequest("GET", "/v1/check?target=invalid", nil),
+			status: http.StatusBadRequest,
+			body:   "cannot extract site from hostname: invalid",
+		},
+		{
+			name:              "failure-getting-content-provider",
+			r:                 httptest.NewRequest("GET", "/v1/check?target=s1.abc01", nil),
+			status:            http.StatusInternalServerError,
+			getConfigMustFail: true,
+		},
+	}
+
+	netconf := &netconfProvider{
+		filepath: "testdata/abc01.conf",
+	}
+
+	provider := &contentProvider{
+		filepath: "testdata/abc01.conf",
+	}
+
+	handler := NewHandler("test", netconf)
+	for _, test := range tests {
+		rr := httptest.NewRecorder()
+
+		handler.getConfigFunc = func(context.Context, *url.URL) (content.Provider, error) {
+			if test.getConfigMustFail {
+				return nil, fmt.Errorf("getConfigFunc() error")
+			}
+			return provider, nil
+		}
+		handler.ServeHTTP(rr, test.r)
+
+		resp := rr.Result()
+
+		if resp.StatusCode != test.status {
+			t.Errorf("ServeHTTP - expected %d, got %d", test.status,
+				resp.StatusCode)
+		}
+
+		if test.body != "" {
+			body, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Errorf("ServeHTTP() - cannot read response: %v", err)
+			}
+			if string(body) != test.body {
+				t.Errorf("ServeHTTP() - unexpected response: \n%s", string(body))
+			}
+		}
+	}
+}
+
+func TestHandler_getProviderForConfig(t *testing.T) {
+	h := NewHandler("test", &netconfProvider{})
+	oldParseURL := parseURL
+	parseURL = func(rawurl string) (*url.URL, error) {
+		return nil, fmt.Errorf("parseURL() error")
+	}
+	_, err := h.getProviderForConfig("://")
+	if err == nil {
+		t.Errorf("getProviderForConfig(): expected err, got nil.")
+	}
+
+	parseURL = oldParseURL
+
+}


### PR DESCRIPTION
This PR adds a handler for `/v1/check?target=<switchhost>` which returns a Prometheus metric that tells us if the specified switch's configuration is the same as the archived one.

It also simplifies main() a lot, since there is no need to call siteinfo / iterate over the results anymore.

The tests in main_test.go are mainly to verify that the objects' initialization, flags reading and plumbing all work as intended. The delay of 500 milliseconds was enough during my tests for main() to execute fully, but if you have suggestions on how to improve that, they are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/switch-monitoring/10)
<!-- Reviewable:end -->
