### PR TITLE
Add 24-hour caching to the /v1/check endpoint

### DIFF
--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -52,9 +52,9 @@ var (
 	flagPassword = flag.String("auth.password", "", "Password for HTTP basic auth")
 
 	flagCacheCapacity = flag.Int("collector.cache-capacity", defaultCacheCapacity,
-		"Maximum # of cached responses for the e2e endpoint")
+		"Maximum # of cached responses for the /check endpoint")
 	flagCacheTTL = flag.Duration("collector.cache-ttl", defaultCacheTTL,
-		"TTL of cached responses for the e2e endpoint")
+		"TTL of cached responses for the /check endpoint")
 
 	flagDebug = flag.Bool("debug", true, "Show debug messages.")
 

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -97,6 +97,21 @@ func main() {
 	collectorHandler = collector.NewHandler(*flagProject, netconf)
 
 	// Create an in-memory cache to avoid connecting to a switch too often.
+	//
+	// Assuming we have enough capacity to keep all the responses in the cache,
+	// the choice of eviction algorithm does not really make a difference.
+	//
+	// If we don't have enough capacity to keep all the responses in memory:
+	//
+	//   - By using MRU, the first capacity - 1 responses will be re-used for
+	//     24 hours and switches - capacity + 1 new SSH connections will be
+	//     made.
+	//   - By using LRU, all the SSH connections will be made each time.
+	//
+	// Both conditions are very undesirable and we should make sure
+	// capacity > switches at all times. However, using MRU significantly
+	// limits the impact when this does not hold true anymore.
+
 	memcache, err := memory.NewAdapter(
 		memory.AdapterWithAlgorithm(memory.MRU),
 		memory.AdapterWithCapacity(*flagCacheCapacity),

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/prometheus/client_golang v1.3.0
 	github.com/scottdware/go-junos v0.0.0-20191101184514-da1ec4631b03
 	github.com/stretchr/testify v1.5.1
+	github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707
 )

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLD
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
+github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707 h1:Pg/LJmFZnr+hlP9sohJKDaxi1nTSOPvGNo8dBBgRIkM=
+github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707/go.mod h1:V7CEaXWuLs0tH3DNWqJO+GVr8YgiAwRgBh76T4LNSPU=
 github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b h1:VfPXB/wCGGt590QhD1bOpv2J/AmC/RJNTg/Q59HKSB0=
 github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b/go.mod h1:IZpXDfkJ6tWD3PhBK5YzgQT+xJWh7OsdwiG8hA2MkO4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
This PR adds caching middleware on top of the handler for /v1/check so that responses are cached for 24 hours before making a new connection to the same switch.

This PR is stacked on top of https://github.com/m-lab/switch-monitoring/pull/10.

Closes #11 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/switch-monitoring/12)
<!-- Reviewable:end -->
