### PR TITLE
Fix wrong GCS URL and site regex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/m-lab/switch-monitoring
 go 1.13
 
 require (
+	cloud.google.com/go/storage v1.6.0 // indirect
 	github.com/apex/log v1.1.2
-	github.com/fsouza/fake-gcs-server v1.18.1 // indirect
-	github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d
 	github.com/kylelemons/godebug v1.1.0
 	github.com/m-lab/go v1.3.1-0.20200403144322-d726433a0387
 	github.com/m-lab/uuid-annotator v0.4.0 // indirect
@@ -13,4 +12,5 @@ require (
 	github.com/scottdware/go-junos v0.0.0-20191101184514-da1ec4631b03
 	github.com/stretchr/testify v1.5.1
 	github.com/victorspringer/http-cache v0.0.0-20190721184638-fe78e97af707
+	google.golang.org/api v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsouza/fake-gcs-server v1.18.1 h1:7fA13aFlR3HWeUTqhrEebl+AV1o9zRBhrur/snOlOCA=
-github.com/fsouza/fake-gcs-server v1.18.1/go.mod h1:iVCT/Bmn6OK+uEnnkJmqxvoT5ei3cL+XCZbuvkZva+Y=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -80,8 +78,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d h1:lBXNCxVENCipq4D1Is42JVOP4eQjlB8TQ6H69Yx5J9Q=
-github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -121,10 +117,6 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20191008195207-8e1d251e947d h1:YBqybTXA//1pltKcwyntNQdgDw6AnA5oHZCXFOiZhoo=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20191008195207-8e1d251e947d/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
-github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -137,6 +129,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -149,9 +142,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/m-lab/go v1.3.0 h1:Gn+AYKSRKBgP4cMc2YxmdT1bmGXSmn/PxqeCSOWfvog=
-github.com/m-lab/go v1.3.1-0.20200402155048-8d172f3e2597 h1:F7ObjxXEO6D3HQEP3/SdiXfi/NrOKU/sXxwSajsguXw=
-github.com/m-lab/go v1.3.1-0.20200402155048-8d172f3e2597/go.mod h1:f22d1CtoFIho8yt0wPNYo0Lx5h8YfgRW4+1pzQTeQRw=
 github.com/m-lab/go v1.3.1-0.20200403144322-d726433a0387 h1:QI7p+runT8ZmGIWTYmDhpmkbwjuLZoBtDKd+UI2JZVk=
 github.com/m-lab/go v1.3.1-0.20200403144322-d726433a0387/go.mod h1:f22d1CtoFIho8yt0wPNYo0Lx5h8YfgRW4+1pzQTeQRw=
 github.com/m-lab/uuid-annotator v0.4.0 h1:UgTNlfpe3fsnakO6A5PLWttdRlHnQNFD45KH4D2rh9A=
@@ -191,6 +181,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
 github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -201,7 +192,6 @@ github.com/scottdware/go-rested v0.0.0-20160313143639-93e152ef32a6/go.mod h1:Pb2
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=

--- a/internal/collector/handler.go
+++ b/internal/collector/handler.go
@@ -90,7 +90,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // getProviderForConfig initializes a content.Provider for the specified site.
 func (h *Handler) getProviderForConfig(site string) (content.Provider, error) {
 	url, err := parseURL(
-		fmt.Sprintf("gs://switch-config-%s/configs/latest/%s.conf",
+		fmt.Sprintf("gs://switch-config-%s/configs/current/%s.conf",
 			h.projectID, site),
 	)
 	if err != nil {
@@ -108,14 +108,14 @@ func (h *Handler) getProviderForConfig(site string) (content.Provider, error) {
 // getSite returns the site name from a FQDN like
 // s1.<site>.measurement-lab.org.
 func getSite(hostname string) (string, error) {
-	re := regexp.MustCompile(`s1\.([a-zA-Z]{3}[0-9]{2}).*`)
+	re := regexp.MustCompile(`s1\.([a-zA-Z]{3}[a-zA-Z0-9]{2}).*`)
 	res := re.FindStringSubmatch(hostname)
 	if len(res) != 2 {
 		return "", fmt.Errorf("cannot extract site from hostname: %s",
 			hostname)
 	}
 
-	return res[0], nil
+	return res[1], nil
 }
 
 // writeError writes an error on the provided ResponseWriter and logs it.

--- a/internal/collector/handler.go
+++ b/internal/collector/handler.go
@@ -108,7 +108,7 @@ func (h *Handler) getProviderForConfig(site string) (content.Provider, error) {
 // getSite returns the site name from a FQDN like
 // s1.<site>.measurement-lab.org.
 func getSite(hostname string) (string, error) {
-	re := regexp.MustCompile(`s1\.([a-zA-Z]{3}[a-zA-Z0-9]{2}).*`)
+	re := regexp.MustCompile(`s1\.([a-z]{3}[0-9ct]{2}).*`)
 	res := re.FindStringSubmatch(hostname)
 	if len(res) != 2 {
 		return "", fmt.Errorf("cannot extract site from hostname: %s",


### PR DESCRIPTION
This PR fixes two small bugs:
- The GCS URL should've been `/configs/current/`
- The `getSite` function returned the whole hostname rather than just the site name and didn't work with testing sites (0t, 1t)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/switch-monitoring/14)
<!-- Reviewable:end -->
