### PR TITLE
Change default SSH user to "switch-monitoring"

### DIFF
--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -24,6 +24,7 @@ import (
 const (
 	defaultListenAddr = ":8080"
 	defaultProjectID  = "mlab-sandbox"
+	defaultSSHUser    = "switch-monitoring"
 
 	// TODO: use v2 hostnames once they are available.
 	// (https://github.com/m-lab/siteinfo/issues/134)
@@ -43,6 +44,8 @@ var (
 	project    = flag.String("project", defaultProjectID,
 		"Use a specific GCP Project ID.")
 
+	sshUsername = flag.String("ssh.username", defaultSSHUser,
+		"Username to use.")
 	sshKey = flag.String("ssh.key", "",
 		"Path to the SSH private key to use.")
 	sshPassphrase = flag.String("ssh.passphrase", "",

--- a/cmd/switch-monitoring/main.go
+++ b/cmd/switch-monitoring/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	// Initialize Siteinfo provider and the NETCONF client.
 	auth := &junos.AuthMethod{
-		Username:   "root",
+		Username:   *sshUsername,
 		PrivateKey: *sshKey,
 		Passphrase: *sshPassphrase,
 	}


### PR DESCRIPTION
This PR makes the SSH username configurable via the `-ssh.username` flag. The previous default was `root`, which isn't a great idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/switch-monitoring/16)
<!-- Reviewable:end -->
