### PR TITLE
Close SSH connection to the switch after reading the configuration

### DIFF
--- a/internal/netconf/client.go
+++ b/internal/netconf/client.go
@@ -27,6 +27,7 @@ func (c Client) GetConfig(hostname string, section ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer jnpr.Close()
 
 	config, err := jnpr.GetConfig("text", section...)
 	if err != nil {

--- a/internal/netconf/client_test.go
+++ b/internal/netconf/client_test.go
@@ -26,7 +26,7 @@ type mockConnection struct {
 	mustFail bool
 }
 
-func (c mockConnection) GetConfig(string, ...string) (string, error) {
+func (c *mockConnection) GetConfig(string, ...string) (string, error) {
 	if c.mustFail {
 		return "", fmt.Errorf("error")
 	}
@@ -37,6 +37,10 @@ func (c mockConnection) GetConfig(string, ...string) (string, error) {
 		return "", err
 	}
 	return string(testfile), nil
+}
+
+func (c *mockConnection) Close() {
+	// not implemented.
 }
 
 func TestNew(t *testing.T) {

--- a/internal/netconf/connector.go
+++ b/internal/netconf/connector.go
@@ -18,6 +18,7 @@ var newSession = junos.NewSessionWithConfig
 
 type connection interface {
 	GetConfig(string, ...string) (string, error)
+	Close()
 }
 
 type connector interface {


### PR DESCRIPTION
switch-monitoring leaves the SSH connection open after reading the configuration from the switch. This PR fixes that.

Closes https://github.com/m-lab/switch-monitoring/issues/18.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/switch-monitoring/19)
<!-- Reviewable:end -->
