### PR TITLE
Use v2 hostnames

### DIFF
--- a/internal/collector/handler.go
+++ b/internal/collector/handler.go
@@ -108,7 +108,7 @@ func (h *Handler) getProviderForConfig(site string) (content.Provider, error) {
 // getSite returns the site name from a FQDN like
 // s1.<site>.measurement-lab.org.
 func getSite(hostname string) (string, error) {
-	re := regexp.MustCompile(`s1\.([a-z]{3}[0-9ct]{2}).*`)
+	re := regexp.MustCompile(`s1(?:\.|-)([a-z]{3}[0-9ct]{2}).*`)
 	res := re.FindStringSubmatch(hostname)
 	if len(res) != 2 {
 		return "", fmt.Errorf("cannot extract site from hostname: %s",

--- a/internal/collector/handler.go
+++ b/internal/collector/handler.go
@@ -108,7 +108,7 @@ func (h *Handler) getProviderForConfig(site string) (content.Provider, error) {
 // getSite returns the site name from a FQDN like
 // s1.<site>.measurement-lab.org.
 func getSite(hostname string) (string, error) {
-	re := regexp.MustCompile(`s1(?:\.|-)([a-z]{3}[0-9ct]{2}).*`)
+	re := regexp.MustCompile(`s1-([a-z]{3}[0-9ct]{2}).*`)
 	res := re.FindStringSubmatch(hostname)
 	if len(res) != 2 {
 		return "", fmt.Errorf("cannot extract site from hostname: %s",

--- a/internal/collector/handler_test.go
+++ b/internal/collector/handler_test.go
@@ -42,6 +42,15 @@ func TestHandler_ServeHTTP(t *testing.T) {
 `,
 		},
 		{
+			name: "ok-configs-match-v2-hostname",
+			r: httptest.NewRequest("GET",
+				"/v1/check?target=s1-abc01.measurement-lab.org", nil),
+			status: http.StatusOK,
+			body: metadata + `switch_monitoring_config_match{status="ok",` +
+				`target="s1-abc01.measurement-lab.org"} 1
+`,
+		},
+		{
 			name:   "method-not-allowed",
 			r:      httptest.NewRequest("POST", "/v1/check", nil),
 			status: http.StatusMethodNotAllowed,

--- a/internal/collector/handler_test.go
+++ b/internal/collector/handler_test.go
@@ -33,15 +33,6 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		getConfigMustFail bool
 	}{
 		{
-			name: "ok-configs-match",
-			r: httptest.NewRequest("GET",
-				"/v1/check?target=s1.abc01.measurement-lab.org", nil),
-			status: http.StatusOK,
-			body: metadata + `switch_monitoring_config_match{status="ok",` +
-				`target="s1.abc01.measurement-lab.org"} 1
-`,
-		},
-		{
 			name: "ok-configs-match-v2-hostname",
 			r: httptest.NewRequest("GET",
 				"/v1/check?target=s1-abc01.measurement-lab.org", nil),
@@ -69,7 +60,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		},
 		{
 			name:              "failure-getting-content-provider",
-			r:                 httptest.NewRequest("GET", "/v1/check?target=s1.abc01", nil),
+			r:                 httptest.NewRequest("GET", "/v1/check?target=s1-abc01", nil),
 			status:            http.StatusInternalServerError,
 			getConfigMustFail: true,
 		},


### PR DESCRIPTION
This PR makes switch-monitoring accept v2 hostnames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/switch-monitoring/20)
<!-- Reviewable:end -->
